### PR TITLE
feat: add release label to pr

### DIFF
--- a/.changes/unreleased/Added-20240917-091722.yaml
+++ b/.changes/unreleased/Added-20240917-091722.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Updated action inputs to allow adding pull request labels
+time: 2024-09-17T09:17:22.951799+02:00

--- a/.changes/unreleased/Dependency-20240917-091755.yaml
+++ b/.changes/unreleased/Dependency-20240917-091755.yaml
@@ -1,0 +1,3 @@
+kind: Dependency
+body: Updated create-pull-request to v7
+time: 2024-09-17T09:17:55.410345+02:00

--- a/action.yaml
+++ b/action.yaml
@@ -102,6 +102,7 @@ runs:
         branch: release/${{ steps.latest.outputs.output }}
         commit-message: Release ${{ steps.latest.outputs.output }}
         token: ${{ inputs.github-token }}
+        labels: release
         body: |
           This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag ${{ steps.latest.outputs.output }} will be created${{ inputs.release-workflow != '' && format(' and the {0} workflow will be started', inputs.release-workflow) || '' }}.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.
 

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,10 @@ inputs:
   release-workflow:
     description: "Name of the release workflow to trigger"
     required: false
+  
+  pull-request-labels:
+    description: "Comma separated or newline-separated list of labels to add to the pull request"
+    required: false
 
 runs:
   using: "composite"
@@ -102,7 +106,7 @@ runs:
         branch: release/${{ steps.latest.outputs.output }}
         commit-message: Release ${{ steps.latest.outputs.output }}
         token: ${{ inputs.github-token }}
-        labels: release
+        labels: ${{ inputs.pull-request-labels }}
         body: |
           This PR was created by the [Changie release GitHub action](https://github.com/labd/changie-release-action). When you're ready to do a release, you can merge this and the tag ${{ steps.latest.outputs.output }} will be created${{ inputs.release-workflow != '' && format(' and the {0} workflow will be started', inputs.release-workflow) || '' }}.  If you're not ready to do a release yet, that's fine, whenever you add more changes to main, this PR will be updated.
 

--- a/action.yaml
+++ b/action.yaml
@@ -95,7 +95,7 @@ runs:
         PACKAGE_VERSION: ${{ steps.latest.outputs.output }}
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7
       if: steps.status.outputs.create_release == 'true'
       with:
         title: Release ${{ steps.latest.outputs.output }}


### PR DESCRIPTION
Adds release label to each PR created by the action. Makes it easier to trigger custom workflows when the created release PR is merged.